### PR TITLE
Replace atomic with mutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unique_port"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Soramitsu Iroha2 team"]
 edition = "2018"
 repository = "https://github.com/soramitsu/iroha2-unique_port"


### PR DESCRIPTION
Replaces `AtomicU16` with `Mutex`.
Updates version to `0.2.1`.